### PR TITLE
Implement SMTP passthrough

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,1 @@
+[inputs: ["mix.exs", "lib/**/*.ex"]]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build
+/deps/

--- a/bin/auth-plain
+++ b/bin/auth-plain
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -z "$2" ]; then
+  echo "Usage: $0 <username> <password>" >&2
+  exit 1
+fi
+
+username=$1
+password=$2
+
+printf "\\0%s\\0%s" "$username" "$password" | base64

--- a/lib/youtrack_mail_proxy.ex
+++ b/lib/youtrack_mail_proxy.ex
@@ -1,0 +1,9 @@
+alias YouTrackMailProxy.SMTPProxy
+
+defmodule YouTrackMailProxy do
+  use SMTPProxy
+
+  def transform(mail) do
+    mail
+  end
+end

--- a/lib/youtrack_mail_proxy/smtp_proxy.ex
+++ b/lib/youtrack_mail_proxy/smtp_proxy.ex
@@ -1,0 +1,75 @@
+defmodule YouTrackMailProxy.SMTPProxy do
+  defmacro __using__(_) do
+    quote do
+      import ConfigMacro
+      config :youtrack_mail_proxy, [{:client_options, []}, {:server_options, []}, :password]
+
+      @behaviour :gen_smtp_server_session
+
+      def init(_, _, _, _), do: {:ok, "SMTP proxy", %{}}
+
+      def code_change(_, state, _), do: {:ok, state}
+      def terminate(_, state), do: {:ok, state}
+
+      def handle_AUTH(_, _, auth_password, state) do
+        if SecureCompare.compare(auth_password, password()) do
+          {:ok, %{auth?: true}}
+        else
+          :error
+        end
+      end
+
+      def handle_DATA(from, to, mime, state) do
+        mime = :mimemail.encode(transform(:mimemail.decode(mime)))
+        id = Integer.to_string(System.unique_integer([:positive]))
+
+        spawn(fn -> relay(from, to, mime) end)
+
+        {:ok, id, state}
+      end
+
+      def handle_EHLO(_, _, state) do
+        {:ok, [{'AUTH', 'PLAIN'}], state}
+      end
+
+      @doc """
+        Always returns 530 on HELO.
+
+        Proxy requires authentication, so it naturally can't handle HELO.
+      """
+      def handle_HELO(_, state) do
+        {:error, "530", state}
+      end
+
+      def handle_MAIL(_, state = %{auth?: true}), do: {:ok, state}
+      def handle_MAIL(_, state), do: {:error, "530", state}
+      def handle_MAIL_extension(_, state), do: :error
+
+      def handle_RCPT(_, state), do: {:ok, state}
+      def handle_RCPT_extension(_, state), do: :error
+
+      def handle_RSET(state), do: %{}
+
+      @doc """
+        Always returns 252 on VRFY.
+
+        Proxy doesn't handle verification.
+      """
+      def handle_VRFY(_, state) do
+        {:error, "252", state}
+      end
+
+      def handle_other(_, _, state), do: {"500", state}
+
+      def relay(from, to, data) do
+        :gen_smtp_client.send({from, to, data}, client_options())
+      end
+
+      @default_server_options [port: 37811]
+
+      def start(_, _) do
+        :gen_smtp_server.start(__MODULE__, [[], server_options() ++ @default_server_options])
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,19 @@
+defmodule YouTrackMailProxy.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :youtrack_mail_proxy,
+      version: "0.0.0",
+      deps: [
+        config_macro: "~> 0.1.0",
+        gen_smtp: "~> 0.12.0",
+        secure_compare: "~> 0.1.0"
+      ]
+    ]
+  end
+
+  def application do
+    [mod: {YouTrackMailProxy, []}]
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "config_macro": {:hex, :config_macro, "0.1.0", "0f818f42a6821d0adca8862b1619c9064e1d69ac1913f53812c798fce52f60a3", [:mix], [], "hexpm"},
+  "gen_smtp": {:hex, :gen_smtp, "0.12.0", "97d44903f5ca18ca85cb39aee7d9c77e98d79804bbdef56078adcf905cb2ef00", [:rebar3], [], "hexpm"},
+  "secure_compare": {:hex, :secure_compare, "0.1.0", "01b3c93c8edb696e8a5b38397ed48e10958c8a5ec740606656445bcbec0aadb8", [:mix], [], "hexpm"},
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "youtrack_mail_proxy";
+  buildInputs = [ elixir telnet ];
+
+  shellHook = ''
+    mix local.hex --force
+    mix local.rebar --force
+    mix deps.get
+  '';
+}


### PR DESCRIPTION
Implement SMTP passthrough proxy for YouTrack (with actual logic added in later after we ensure that `mimemail` implementation is good enough for YouTrack notifications).

The end goal is to include issue IDs in `From:` header to use YouTrack as mailing list substitute more effectively.